### PR TITLE
Trigger an event when arrows are updated

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -2826,7 +2826,9 @@
                 _.$prevArrow.removeClass('slick-disabled').attr('aria-disabled', 'false');
 
             }
-
+          
+          _.$slider.trigger('arrowsUpdated');
+          
         }
 
     };


### PR DESCRIPTION
I have a relatively long vertical slider which at times can extend to be longer than the users viewport. To improve the user experience, I've decided to show previous and next buttons both at the top and bottom of the carousel:

<img width="395" alt="slick" src="https://cloud.githubusercontent.com/assets/2486712/15276293/b98b16dc-1ab1-11e6-98dc-e69c3f08657e.png">

I do this by duplicating the existing prev/next buttons after the slider is initialized, adding some extra classes so I know which buttons belong at the top and bottom, and then positioning appropriately via CSS.

Then, I bind events to the click events on these new duplicate buttons and call the `slickNext` and `slickPrev` to get the slider to slide. So far, everything works fine.

The issue I'm having is that I can't find a way to reliably keep the new next/prev buttons in sync with the existing ones. For example, when the first slide is reached and the original previous button gets the 'slick-disabled' class, the new duplicate one should as well so that they both enter the disabled state simultaneously. I tried to do this by using the `afterChange` event, but this even fires after the slide changes and animation completes, while the original buttons are updated before the animation starts. The `beforeChange` event doesn't work either because that fires before the original buttons are updated.

So, all of this boils down to the one line I added which fires an event when the arrows are updated, allowing any additional arrows to update themselves at the same time. This is working for me.

I was thinking that a better solution might be to add an option for `arrowSets`, allowing the user to request a specific amount of arrow sets to be created. It would of course default to 1, but if I wanted to request 2 sets of arrows, the library could generate them for me, assigning each set a unique class so that they can be identified using CSS. For example, in addition to the normal classes the arrows get, the first prev/next arrow would also have the class `slick-arrow-0` and the second set would have `slick-arrow-1`.

Let me know if you would prefer to see a pull request for that implementation.